### PR TITLE
Fix crash with structures/features that hold jukeboxes, and move asserts

### DIFF
--- a/src/main/java/net/sydokiddo/auditory/AuditoryClient.java
+++ b/src/main/java/net/sydokiddo/auditory/AuditoryClient.java
@@ -25,8 +25,7 @@ public class AuditoryClient implements ClientModInitializer {
 
         KeyBindingHelper.registerKeyBinding(reloadKey);
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
-            if (reloadKey.isDown()) {
-                assert client.player != null;
+            if (reloadKey.isDown() && client.player != null) {
                 Minecraft.getInstance().getSoundManager().reload();
                 Minecraft mc = Minecraft.getInstance();
                 mc.gui.getChat().addMessage(Component.translatable("auditory.sound_reload_message"));

--- a/src/main/java/net/sydokiddo/auditory/mixin/blocks/JukeboxDiscSoundMixin.java
+++ b/src/main/java/net/sydokiddo/auditory/mixin/blocks/JukeboxDiscSoundMixin.java
@@ -3,7 +3,6 @@ package net.sydokiddo.auditory.mixin.blocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.JukeboxSong;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -16,7 +15,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Optional;
 
@@ -46,9 +44,8 @@ public abstract class JukeboxDiscSoundMixin extends BlockEntity {
 
     @Inject(method = "setTheItem", at = @At("HEAD"))
     private void auditory_insertDiscSound(ItemStack itemStack, CallbackInfo ci) {
-        if (Auditory.getConfig().block_sounds.jukebox_sounds) {
+        if (Auditory.getConfig().block_sounds.jukebox_sounds && this.level != null) {
             boolean bl = !itemStack.isEmpty();
-            assert this.level != null;
             Optional<Holder<JukeboxSong>> optional = JukeboxSong.fromStack(this.level.registryAccess(), itemStack);
             if (bl && optional.isPresent()) {
                 this.level.playSound(null, this.getBlockPos(), ModSoundEvents.BLOCK_JUKEBOX_USE, SoundSource.BLOCKS, 1.0F, 1.0F);


### PR DESCRIPTION
Fun fact! I learned the hard way that assertions are useless unless you have them explicitly enabled / are running in debug mode on IntelliJ!